### PR TITLE
[TASK] fix tablename for fe_users table in JumpUrl Middleware

### DIFF
--- a/Classes/Middleware/JumpurlController.php
+++ b/Classes/Middleware/JumpurlController.php
@@ -37,7 +37,7 @@ class JumpurlController implements MiddlewareInterface
 {
 
     public const RECIPIENT_TABLE_TTADDRESS = 'tt_address';
-    public const RECIPIENT_TABLE_FEUSER = 'fe_user';
+    public const RECIPIENT_TABLE_FEUSER = 'fe_users';
 
     public const RESPONSE_TYPE_URL = -1;
     public const RESPONSE_TYPE_HREF = 1;


### PR DESCRIPTION
The JumpUrl-Middleware causes exceptions because the FEUser table name is "fe_users" not "fe_user".